### PR TITLE
Npc units Attach

### DIFF
--- a/Love Matcher/Assets/Prefabs/Npc.prefab
+++ b/Love Matcher/Assets/Prefabs/Npc.prefab
@@ -13,6 +13,8 @@ GameObject:
   - component: {fileID: 4385308428033854649}
   - component: {fileID: 4385308428033854652}
   - component: {fileID: 2684776777060622994}
+  - component: {fileID: -5732671481446071432}
+  - component: {fileID: -36432518525747959}
   m_Layer: 20
   m_Name: Npc
   m_TagString: Unit
@@ -120,12 +122,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9f27b401d5c49f94381dbbf62613ca1d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  interests:
-  - {fileID: 21300000, guid: 29c9cded5e558164aaf8c9bf08aa1510, type: 3}
-  - {fileID: 21300038, guid: 29c9cded5e558164aaf8c9bf08aa1510, type: 3}
-  - {fileID: 21300066, guid: 29c9cded5e558164aaf8c9bf08aa1510, type: 3}
+  interest: {fileID: 0}
   interestSprite: {fileID: 8584473747112363613}
   npc: {fileID: 1129772792892010370}
+  moving: 0
 --- !u!61 &2684776777060622994
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -152,6 +152,34 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.0025091, y: 0.44037342}
   m_EdgeRadius: 0
+--- !u!114 &-5732671481446071432
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1129772792892010370}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a793138d557fae458262f791baf339a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  particle1: {fileID: 1202522996400206, guid: f87e7926fd589094b8a269e14b8bea5e, type: 3}
+  particle2: {fileID: 6458890441269194243, guid: cd9469e475be75d4ab5c6fa56d40b7f1,
+    type: 3}
+--- !u!114 &-36432518525747959
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1129772792892010370}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 350250f91ad635e47b07918dc9f2ace3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _speed: 10
 --- !u!1 &8584473747112363613
 GameObject:
   m_ObjectHideFlags: 0

--- a/Love Matcher/Assets/Scenes/DragTestScene.unity
+++ b/Love Matcher/Assets/Scenes/DragTestScene.unity
@@ -1636,6 +1636,11 @@ PrefabInstance:
       propertyPath: m_Constraints
       value: 4
       objectReference: {fileID: 0}
+    - target: {fileID: 4385308428033854652, guid: 93559432976645f4ca2c46a3d04205cf,
+        type: 3}
+      propertyPath: interest
+      value: 
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 93559432976645f4ca2c46a3d04205cf, type: 3}
 --- !u!4 &467659234 stripped
@@ -3096,40 +3101,6 @@ MonoBehaviour:
   m_InstancedGameObject: {fileID: 0}
   m_Flags: 3
   m_ColliderType: 1
---- !u!1 &1088932063 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1129772792892010370, guid: 93559432976645f4ca2c46a3d04205cf,
-    type: 3}
-  m_PrefabInstance: {fileID: 1656347419}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1088932064
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1088932063}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4a793138d557fae458262f791baf339a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  particle1: {fileID: 1202522996400206, guid: f87e7926fd589094b8a269e14b8bea5e, type: 3}
-  particle2: {fileID: 6458890441269194243, guid: cd9469e475be75d4ab5c6fa56d40b7f1,
-    type: 3}
---- !u!114 &1088932065
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1088932063}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 350250f91ad635e47b07918dc9f2ace3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _speed: 10
 --- !u!1 &1144419588
 GameObject:
   m_ObjectHideFlags: 0
@@ -3353,7 +3324,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1271711196}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 10.22, y: -0.17, z: 0}
+  m_LocalPosition: {x: 19.45, y: -1.18, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -3548,40 +3519,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _speed: 10
---- !u!1 &1440648592 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1129772792892010370, guid: 93559432976645f4ca2c46a3d04205cf,
-    type: 3}
-  m_PrefabInstance: {fileID: 440055032}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1440648598
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1440648592}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 350250f91ad635e47b07918dc9f2ace3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _speed: 10
---- !u!114 &1440648599
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1440648592}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4a793138d557fae458262f791baf339a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  particle1: {fileID: 1202522996400206, guid: f87e7926fd589094b8a269e14b8bea5e, type: 3}
-  particle2: {fileID: 6458890441269194243, guid: cd9469e475be75d4ab5c6fa56d40b7f1,
-    type: 3}
 --- !u!1 &1443487436
 GameObject:
   m_ObjectHideFlags: 0
@@ -4870,7 +4807,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1819972589}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 12.07, y: -0.05, z: 0}
+  m_LocalPosition: {x: 19.32, y: 0.85, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Love Matcher/Assets/Scripts/Drag Scripts/DragObject.cs
+++ b/Love Matcher/Assets/Scripts/Drag Scripts/DragObject.cs
@@ -6,6 +6,7 @@ public class DragObject : MonoBehaviour
 {
     private Vector3 _dragOffset;
     private Camera _cam;
+    private bool dragging = false;
     [SerializeField] private float _speed = 10;
 
     void Awake()
@@ -15,13 +16,22 @@ public class DragObject : MonoBehaviour
 
     void OnMouseDown()
     {
-        if(transform.gameObject.tag == "Draggable") _dragOffset = transform.position - GetMousePos();
+        if (transform.gameObject.tag == "Draggable")
+        {
+            _dragOffset = transform.position - GetMousePos();
+            transform.gameObject.tag = "Dragging";
+        }
+    }
+
+    void OnMouseUp()
+    {
+        transform.gameObject.tag = "Draggable";
     }
 
     void OnMouseDrag()
     {
         //transform.position = GetMousePos() + _dragOffset;
-        if (transform.gameObject.tag == "Draggable") transform.position = Vector3.MoveTowards(transform.position, GetMousePos() + _dragOffset, _speed * Time.deltaTime);
+        if (transform.gameObject.tag == "Dragging") transform.position = Vector3.MoveTowards(transform.position, GetMousePos() + _dragOffset, _speed * Time.deltaTime);
     }
 
     Vector3 GetMousePos()

--- a/Love Matcher/Assets/Scripts/Drag Scripts/UnitCollider.cs
+++ b/Love Matcher/Assets/Scripts/Drag Scripts/UnitCollider.cs
@@ -11,13 +11,19 @@ public class UnitCollider : MonoBehaviour
     void OnCollisionEnter2D(Collision2D col)
     {
 
-        if (col.gameObject.name == "Arrow(Clone)" && transform.gameObject.tag != "Draggable")
+        if (col.gameObject.name == "Arrow(Clone)" && transform.gameObject.tag == "Unit")
         {
             transform.gameObject.tag = "Draggable";
             var parti1 = GameObject.Instantiate(particle1, this.transform);
-            //parti1.transform.position = new Vector3(transform.position.x, transform.position.y, transform.position.z);
         }
-            Debug.Log("Collision!");
+        else if (transform.gameObject.tag == "Dragging" && col.gameObject.tag == "Draggable")
+        {
+            transform.SetParent(col.gameObject.transform, true);
+            this.gameObject.GetComponent<Npc>().SetFollow(col.gameObject);
+            transform.gameObject.tag = "Untagged";
+
+        }
+            //Debug.Log("Collision!");
 
             var parti2 = GameObject.Instantiate(particle2);
             parti2.transform.position = new Vector3(transform.position.x, transform.position.y, transform.position.z);

--- a/Love Matcher/Assets/Scripts/Npc.cs
+++ b/Love Matcher/Assets/Scripts/Npc.cs
@@ -4,17 +4,16 @@ using UnityEngine;
 
 public class Npc : MonoBehaviour
 {
-    public Sprite[] interests;
-    public GameObject interestSprite;
-    public GameObject npc;
+    public Sprite interest;
+    public GameObject interestSprite, npc;
     private Rigidbody2D rb;
     private Vector3 movementDirection = new Vector3(1, 0, 0);
-    private bool moving = false;
+    public bool moving = false;
     // Start is called before the first frame update
     void Start()
     {
         rb = npc.GetComponent<Rigidbody2D>();
-        interestSprite.GetComponent<SpriteRenderer>().sprite = interests[Random.Range(0,2)];
+        interestSprite.GetComponent<SpriteRenderer>().sprite = interest;
     }
 
     // Update is called once per frame
@@ -24,6 +23,7 @@ public class Npc : MonoBehaviour
         SpriteCheck();
         if (moving == false)
         {
+            //Debug.Log("move");
             StartCoroutine("move"); // this is created so that npcs can have other things than just movement
         }
     }
@@ -37,7 +37,7 @@ public class Npc : MonoBehaviour
     }
 
     private void newDirection()
-    {
+    { 
         movementDirection = new Vector3(Random.Range(-1f, 1f), Random.Range(-1f, 1f), 0);
     }
 
@@ -62,13 +62,18 @@ public class Npc : MonoBehaviour
 
         if(contactPoint.x > center.x)
         {
-            Debug.Log("side");
+            //Debug.Log("side");
             movementDirection.x = movementDirection.x * -1;
         }
         else
         {
-            Debug.Log("top/bottom");
+            //Debug.Log("top/bottom");
             movementDirection.y = movementDirection.y * -1;
         }
+    }
+
+    public void SetFollow(GameObject l)
+    { 
+        this.GetComponent<Rigidbody2D>().isKinematic = true;
     }
 }

--- a/Love Matcher/ProjectSettings/TagManager.asset
+++ b/Love Matcher/ProjectSettings/TagManager.asset
@@ -6,6 +6,7 @@ TagManager:
   tags:
   - Unit
   - Draggable
+  - Dragging
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Npc units now attach when two draggable objects collide. When attached, the attached unit will stop moving and move with the collided object. New tag for object being dragged. Npc interests are removed.