### PR TITLE
Attached Unit Properly Undraggable

### DIFF
--- a/Love Matcher/Assets/Scripts/Drag Scripts/DragObject.cs
+++ b/Love Matcher/Assets/Scripts/Drag Scripts/DragObject.cs
@@ -25,7 +25,7 @@ public class DragObject : MonoBehaviour
 
     void OnMouseUp()
     {
-        transform.gameObject.tag = "Draggable";
+        if(transform.gameObject.tag == "Dragging") transform.gameObject.tag = "Draggable";
     }
 
     void OnMouseDrag()


### PR DESCRIPTION
OnMouseDown was incorrectly setting the untagged unit back to draggable when it was supposed to be undraggable. It should now remain untagged and undraggable after it is attached. 